### PR TITLE
Forenkling (trenger ikke skille på mottakertype)

### DIFF
--- a/data/isdialogmote/avlysning.json
+++ b/data/isdialogmote/avlysning.json
@@ -1,0 +1,19 @@
+[
+  {
+  "type": "PARAGRAPH",
+  "texts": ["Gjelder Artig Trane, f.nr. 12345678945"]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": ["NAV har tidligere innkalt til dialogmøte som skulle vært avholdt 22.10.2021 klokka 12. Dette møtet er avlyst."]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": ["Her kommer en fritekst skrevet av veilederen."]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": ["Med hilsen", "NAV Staden", "Kari Saksbehandler"]
+  }
+]
+

--- a/data/isdialogmote/endring-tidsted.json
+++ b/data/isdialogmote/endring-tidsted.json
@@ -1,0 +1,30 @@
+[
+  {
+    "type": "PARAGRAPH",
+    "title": "Møtetidspunkt",
+    "texts": ["20. mai 2021, Storgata 4"]
+  },
+  {
+    "type": "PARAGRAPH",
+    "title": "Møtested",
+    "texts": ["Videomøte på Teams"]
+  },
+  {
+    "type": "LINK",
+    "title": "Lenke til videomøte",
+    "texts": ["https://teams.microsoft.com/l/osv.osv.osv"]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": ["Gjelder Artig Trane, f.nr. 12345678945"]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": ["Tid og/eller sted for dialogmøtet har blitt endret."]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": ["Med hilsen", "NAV Staden", "Kari Saksbehandler", "kari@nav.no", "99998888"]
+  }
+]
+

--- a/data/isdialogmote/innkalling.json
+++ b/data/isdialogmote/innkalling.json
@@ -1,0 +1,51 @@
+[
+  {
+    "type": "PARAGRAPH",
+    "title": "Møtetidspunkt",
+    "texts": ["20. mai 2021, Storgata 4"]
+  },
+  {
+    "type": "PARAGRAPH",
+    "title": "Møtested",
+    "texts": ["Videomøte på Teams"]
+  },
+  {
+    "type": "LINK",
+    "title": "Lenke til videomøte",
+    "texts": ["https://teams.microsoft.com/l/osv.osv.osv"]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": ["Gjelder Artig Trane, f.nr. 12345678945"]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": ["Velkommen til dialogmøte mellom deg, arbeidsgiveren din og en veileder fra NAV. I møtet skal vi snakke om situasjonen din og bli enige om en plan som kan hjelpe deg videre."]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": ["Her kommer en fritekst skrevet av veilederen."]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": ["Vi gjør oppmerksom på at det er obligatorisk å delta i dialogmøter med NAV og sende inn oppfølgingsplan på forhånd. Oppdatert oppfølgingsplan skal sendes til NAV senest 1 uke før møtet avholdes."]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": ["Hvis vårt forslag til møtetidspunkt, møtested eller møteform ikke passer, ber vi om at du tar kontakt for å diskutere alternativer.] I så fall kan du sende epost eller ringe undertegnede på telefon. Vi minner om at det ikke må sendes sensitive personopplysninger over e-post eller SMS."]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": ["Etter reglene kan NAV be sykmelder eller annet helsepersonell om å delta i møtet. Til dette møtet har vi ikke sett behov for det."]
+  },
+  {
+    "type": "PARAGRAPH",
+    "title": "Før møtet",
+    "texts": ["Det er viktig at dere fyller ut oppfølgingsplanen sammen og deler den med NAV. Det gir oss et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover."]
+  },
+  {
+    "type": "PARAGRAPH",
+    "texts": ["Med hilsen", "NAV Staden", "Kari Saksbehandler", "kari@nav.no", "99998888"]
+  }
+]
+

--- a/templates/isdialogmote/avlysning.hbs
+++ b/templates/isdialogmote/avlysning.hbs
@@ -1,0 +1,1 @@
+{{> isdialogmote/partials/base items=this doctitle="Dialogmøte" heading="Avlysning av dialogmøte"}}

--- a/templates/isdialogmote/endring-tidsted.hbs
+++ b/templates/isdialogmote/endring-tidsted.hbs
@@ -1,0 +1,1 @@
+{{> isdialogmote/partials/base items=this doctitle="Dialogmøte" heading="Endring av dialogmøte"}}

--- a/templates/isdialogmote/innkalling.hbs
+++ b/templates/isdialogmote/innkalling.hbs
@@ -1,0 +1,1 @@
+{{> isdialogmote/partials/base items=this doctitle="Dialogmøte" heading="Innkalling til dialogmøte"}}


### PR DESCRIPTION
I stedet for å lage nye varianter for behandler foreslår jeg at vi forenkler og ikke skiller på mottakertype her. Pga documentComponent-dto-opplegget så trengs ikke det. Sletter de gamle når vi har fått tilpasset isdialogmote til å bruke disse nye generiske variantene.